### PR TITLE
Redirect user from the API Information Pages if not signed in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,7 @@ workflows:
                 yarn: true
                 start: yarn testStart
                 store_artifacts: true
+                parallel: true
                 requires:
                   - install-dependencies
             - assume-role-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,7 @@ workflows:
             - cypress/run:
                 yarn: true
                 start: yarn testStart
+                store_artifacts: true
                 requires:
                   - install-dependencies
             - assume-role-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,7 @@ workflows:
                   context: api-assume-role-development-context
                   requires:
                       - cypress/run
+                      - run-lint
             - terraform-init-and-apply-to-development:
                   requires:
                       - assume-role-development

--- a/cypress/integration/viewAllApis.spec.js
+++ b/cypress/integration/viewAllApis.spec.js
@@ -1,12 +1,13 @@
 import { screenSizes } from "../support/screenSizes";
 
 describe("API Catalogue is limited to signed in users", () => {
-        it("Redirects to homepage if user is not signed in", function (){
-          cy.visit("/");
-          cy.contains('API CATALOGUE').click();
-          cy.url().should("eq", "http://localhost:3000/");
-        });
-  });
+    it("Redirects to homepage if user is not signed in", function (){
+        cy.visit("/");
+        cy.contains('API CATALOGUE').click();
+        cy.url().should("eq", "http://localhost:3000/");
+    });
+});
+
 describe("View API Catalogue page", () => {
 
     beforeEach(function () {

--- a/cypress/integration/viewApiInformation.spec.js
+++ b/cypress/integration/viewApiInformation.spec.js
@@ -1,5 +1,12 @@
 import { screenSizes } from "../support/screenSizes";
 
+describe("API Information Page is limited to signed in users", () => {
+    it("Redirects to homepage if user is not signed in", function (){
+        cy.visit("/api-catalogue/testApi");
+        cy.url().should("eq", "http://localhost:3000/");
+    });
+});
+
 describe("View API Information page", () => {
 
     beforeEach(function () {

--- a/src/pages/apiCatalogue/apiCatalogue.page.jsx
+++ b/src/pages/apiCatalogue/apiCatalogue.page.jsx
@@ -1,5 +1,9 @@
 import React, { useState, useEffect } from "react";
 
+import { useUser } from "../../context/user.context.js";
+import { useHistory } from "react-router-dom";
+import withUser from "../../HOCs/with-user.hoc.js";
+
 import ApiPreview from "../../components/apiPreview/apiPreview.component";
 import Breadcrumbs from "../../components/breadcrumbs/breadcrumbs.component";
 import Error from "../../components/error/error.component"
@@ -8,14 +12,12 @@ import Pagination from "../../components/pagination/pagination.component";
 import BackToTop from "../../components/backToTop/backToTop.component";
 import Select from "../../components/select/select.component";
 import Details from "../../components/details/details.component";
-import { useUser } from "../../context/user.context.js";
-import { useHistory } from "react-router-dom";
-import withUser from "../../HOCs/with-user.hoc.js";
 
-const ApiCataloguePage = ({ currentUser: user }) => {
+const ApiCataloguePage = () => {
   const currentuser = useUser();
   const history = useHistory();
   if (!currentuser) history.push("/");
+
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
   const [apis, setApis] = useState([]);

--- a/src/pages/apiInformation/apiInformation.page.jsx
+++ b/src/pages/apiInformation/apiInformation.page.jsx
@@ -2,7 +2,9 @@ import { React, useEffect, useState } from "react";
 import { useLocation, useParams } from "react-router";
 
 import withUser from "../../HOCs/with-user.hoc.js";
-import { filterSwaggerPropertiesByType } from "../../utility/utility"
+import { filterSwaggerPropertiesByType } from "../../utility/utility";
+import { useUser } from "../../context/user.context.js";
+import { useHistory } from "react-router-dom";
 
 import Table from "../../components/table/table.component.jsx";
 import Breadcrumbs from "../../components/breadcrumbs/breadcrumbs.component.jsx";
@@ -11,6 +13,10 @@ import Error from "../../components/error/error.component";
 import EnvironmentTags from "../../components/environmentTags/environmentTags.component.jsx";
 
 const ApiInformationPage = () => {
+    const currentuser = useUser();
+    const history = useHistory();
+    if (!currentuser) history.push("/");
+    
     const { apiName } = useParams();
     const apiRequestUrl = `https://api.swaggerhub.com/apis/Hackney/${apiName}`;
     const passedParams = useLocation().state || {versions: null, currentVersion: null };


### PR DESCRIPTION
## Issue
Currently, the user is redirected from the API Catalogue Page if they're not signed in. However, this doesn't apply to if they directly access the API Information Pages (`/api-catalogue/:id`). This functionality has been added so that they are also redirected from that page if not logged in.

## Changes introduced
- Fixed above issue
- Small CircleCI config improvements (store test outputs as artifacts, parallelise tests, require linting to pass before deploying to dev)
