### PR TITLE
Set the colours of environment tags & remove them from the API Catalogue page

### DIFF
--- a/cypress/fixtures/allApis.json
+++ b/cypress/fixtures/allApis.json
@@ -8,7 +8,7 @@
         {
             "name": "Test API",
             "description": "This is a specification for the Test API that allows us to test that the site is working as expected",
-            "tags": ["Development"],
+            "tags": ["Development", "Staging", "Production", "Deprecated"],
             "properties": [
                 {
                     "type": "Swagger",

--- a/cypress/fixtures/testApi.json
+++ b/cypress/fixtures/testApi.json
@@ -361,6 +361,18 @@
         {
             "name": "Development",
             "description": "Marks this API as available in its development enviroment."
+        },
+        {
+            "name": "Staging",
+            "description": "Marks this API as available in its staging enviroment."
+        },
+        {
+            "name": "Production",
+            "description": "Marks this API as available in its production enviroment."
+        },
+        {
+            "name": "Deprecated",
+            "description": "Marks this API as deprecated. It is no longer being used."
         }
     ],
     "schemes": [

--- a/cypress/integration/previewApi.spec.js
+++ b/cypress/integration/previewApi.spec.js
@@ -60,26 +60,12 @@ describe("Preview an API", () => {
         it(`View active status tag on ${screenSize} screen`, function () {
             cy.viewport(screenSize);
             const isPublished = filterSwaggerPropertiesByType(this.apiData.properties, "X-Published").value.toLowerCase() == "true";
-            const expectedClass = isPublished ? "lbh-tag" : "lbh-tag--grey";
+            const expectedClass = isPublished ? "lbh-tag" : "lbh-tag--red";
             cy.get(".apiPreview").find(".top > span.govuk-tag").first().should(($tag) => {
                 const tagText = $tag.text();
                 const expectedTagText = isPublished ? "Active" : "Inactive";
                 expect(tagText).to.equal(expectedTagText);
             }).should('have.class', expectedClass);
-        });
-
-        it(`View environment status tags on ${screenSize} screen`, function () {
-            cy.viewport(screenSize);
-            const expectedEnvTagsNo = 3;
-            cy.get(".apiPreview").find(".env-tags").first().children()
-                .should('have.length', expectedEnvTagsNo)
-                .each((tag) => {
-                    if (this.apiData.tags.includes(tag.text())){
-                        expect(tag).to.have.class("lbh-tag--green");
-                    } else {
-                        expect(tag).to.have.class("lbh-tag--grey");
-                    }
-                });
         });
     });
 });

--- a/cypress/integration/viewApiInformation.spec.js
+++ b/cypress/integration/viewApiInformation.spec.js
@@ -38,14 +38,26 @@ describe("View API Information page", () => {
 
         it(`View environment status tags on ${screenSize} screen`, function () {
             cy.viewport(screenSize);
-            const expectedEnvTagsNo = 3;
+            const expectedEnvTagsNo = 4;
             cy.get(".sidePanel").find(".env-tags").first().children()
                 .should('have.length', expectedEnvTagsNo)
                 .each((tag) => {
-                    if (this.apiData.tags.filter( apiTag => apiTag.name === tag.text()).length > 0){
-                        expect(tag).to.have.class("lbh-tag--green");
+                    const tagText = tag.text();
+                    if (this.apiData.tags.filter( apiTag => apiTag.name === tagText).length > 0){
+                        var tagColour;
+                        switch(tagText){
+                            case "Development":
+                                tagColour = "yellow"; break;
+                            case "Staging":
+                                tagColour = "yellow"; break;
+                            case "Production":
+                                tagColour = "green"; break;
+                            case "Deprecated":
+                                tagColour = "red"; break;
+                        }
+                        expect(tag).to.have.class(`lbh-tag--${tagColour}`);
                     } else {
-                        expect(tag).to.have.class("lbh-tag--grey");
+                        expect(tag).to.have.class(`lbh-tag--${tagText === "Deprecated"? "hidden" : "grey"}`);
                     }
                 });
         });

--- a/src/components/apiPreview/apiPreview.component.jsx
+++ b/src/components/apiPreview/apiPreview.component.jsx
@@ -1,9 +1,8 @@
 import React from "react";
-import EnvironmentTags from "../environmentTags/environmentTags.component";
 import { Link } from "react-router-dom";
 import { filterSwaggerPropertiesByType } from "../../utility/utility";
 
-const ApiPreview = ({name, description, tags, properties}) => {
+const ApiPreview = ({name, description, properties}) => {
 
   const id = filterSwaggerPropertiesByType(properties, "Swagger").url.split("/")[5];
   const isPublished = filterSwaggerPropertiesByType(properties, "X-Published").value.toLowerCase() === "true";
@@ -26,10 +25,9 @@ const ApiPreview = ({name, description, tags, properties}) => {
             <p className="lbh-body-xs"><span className="version">v{selectedVersion}</span> &#183; <span className="edited">Edited {lastModified}</span></p>
           </div>
         </div>
-        <span className={`govuk-tag lbh-tag${isPublished ? "" : "--grey"}`}>{ isPublished ? "Active" : "Inactive" }</span>
+        <span className={`govuk-tag lbh-tag${isPublished ? "" : "--red"}`}>{ isPublished ? "Active" : "Inactive" }</span>
       </div>
       <p className="description">{description}</p>
-      <EnvironmentTags tags={tags} />
     </li>
   );
 };

--- a/src/components/apiPreview/apiPreview.style.scss
+++ b/src/components/apiPreview/apiPreview.style.scss
@@ -4,6 +4,8 @@
     border-radius: 3px;
     list-style-type: none;
 
+    .description { margin-bottom: 0.5em; }
+
     .top {
         display: flex;
         justify-content: space-between;

--- a/src/components/environmentTags/environmentTags.component.jsx
+++ b/src/components/environmentTags/environmentTags.component.jsx
@@ -3,9 +3,10 @@ const EnvironmentTags = ({tags}) => {
 
   return(
   <div className="env-tags">
-      <span className={`govuk-tag lbh-tag lbh-tag${tags.includes("Development") ? "--green" : "--grey"}`}>Development</span>
-      <span className={`govuk-tag lbh-tag lbh-tag${tags.includes("Staging") ? "--green" : "--grey"}`}>Staging</span>
+      <span className={`govuk-tag lbh-tag lbh-tag${tags.includes("Development") ? "--yellow" : "--grey"}`}>Development</span>
+      <span className={`govuk-tag lbh-tag lbh-tag${tags.includes("Staging") ? "--yellow" : "--grey"}`}>Staging</span>
       <span className={`govuk-tag lbh-tag lbh-tag${tags.includes("Production") ? "--green" : "--grey"}`}>Production</span>
+      <span className={`govuk-tag lbh-tag lbh-tag${tags.includes("Deprecated") ? "--red" : "--hidden"}`}>Deprecated</span>
     </div>
   )
 }

--- a/src/components/environmentTags/environmentTags.style.scss
+++ b/src/components/environmentTags/environmentTags.style.scss
@@ -6,4 +6,5 @@
     .lbh-tag {
         margin: 0;
     }
+    .lbh-tag--hidden { display: none; }
 }

--- a/src/pages/apiInformation/apiInformation.page.jsx
+++ b/src/pages/apiInformation/apiInformation.page.jsx
@@ -19,7 +19,7 @@ const ApiInformationPage = () => {
     
     const { apiName } = useParams();
     const apiRequestUrl = `https://api.swaggerhub.com/apis/Hackney/${apiName}`;
-    const passedParams = useLocation().state || {versions: null, currentVersion: null };
+    const passedParams = useLocation().state || { versions: null, currentVersion: null };
 
     const [error, setError] = useState(null);
     const [isLoaded, setIsLoaded] = useState(false);
@@ -46,9 +46,9 @@ const ApiInformationPage = () => {
         }
 
         const handleApiVersioning = (result) => {
-            const versions = result.apis.map( api => filterSwaggerPropertiesByType(api.properties, "X-Version").value);
-            setVersions(versions);
-            setCurrentVersion(versions[0]);
+            const apiVersions = result.apis.map( api => filterSwaggerPropertiesByType(api.properties, "X-Version").value);
+            setVersions(apiVersions);
+            setCurrentVersion(apiVersions[0]);
         }
 
         window.scrollTo(0, 0);
@@ -66,7 +66,7 @@ const ApiInformationPage = () => {
 
     const formatApiData = () => {
         const changeVersion = (version) => { setCurrentVersion(version); }
-        const SelectVersion = <Select name={"VersionNo"} options={versions} selectedOption={currentVersion} onChange={changeVersion} />;
+        const SelectVersion = <Select name={"VersionNo"} options={versions.map(v => v.replace(/^\*(.*)/gm, 'v$1 [PUBLISHED]'))} selectedOption={currentVersion} onChange={changeVersion} />;
 
         const Links = [
             {linkText: `${apiData.swaggerData.info.title} Specification`, url: apiData.apiSpecificationLink},


### PR DESCRIPTION
- Environment tags change colour depending on the environment
- Added support for 'deprecated' tags
- Removed the tags from API previews as SwaggerHub's API does not return them
- Switched inactive tag colour to red from grey
- Add [PUBLISHED] message on version selector

Preview changes on [development](https://developer-api-development.hackney.gov.uk/).
<img width="1004" alt="Screenshot 2021-12-15 at 16 24 03" src="https://user-images.githubusercontent.com/41153116/146356769-8e8da656-1667-40c8-8f38-96aefeb30f28.png">
<img width="1150" alt="Screenshot 2021-12-15 at 16 24 31" src="https://user-images.githubusercontent.com/41153116/146356780-acb38b89-986c-45fd-918f-019135017952.png">

