### PR TITLE
Make the logic for Environment Tags case-insensitive

### DIFF
--- a/cypress/integration/viewApiInformation.spec.js
+++ b/cypress/integration/viewApiInformation.spec.js
@@ -103,7 +103,7 @@ describe("View API Information page", () => {
 
 });
 
-describe("Error Handling", () => {
+describe("Edge Cases", () => {
     beforeEach(function () {
         cy.login()
         cy.intercept('GET', '/specs*', {fixture: "allApis"}).as("getAllApis");
@@ -151,5 +151,19 @@ describe("Error Handling", () => {
         cy.get(".lbh-error-summary").should('be.visible');
         cy.get(".govuk-error-summary__body").should("contain", "Error: Request failed with status code 500 | Error: Request failed with status code 500");
         // assert
+    });
+    
+    it("Shows environment tags that are case insensitive", function () {
+        cy.fixture("testApiSwagger").then((apiSwagger) => {
+            const devTagIndex = apiSwagger.tags.findIndex(x => x.name == "Development");
+            apiSwagger.tags[devTagIndex] = { "name": "dEveLOPmenT", "description": "Marks this API as available in its development enviroment."}
+            cy.intercept('GET', /apis/gm, apiSwagger).as("getSwaggerInfo");
+        });
+        cy.intercept({method: 'GET', url: /api\/v1/gm}, { fixture: "testApi.json"}).as("getApiInfo");
+
+        cy.visit("/api-catalogue");
+        cy.get(".apiPreview").find("a").first().click();
+        // navigate from API Catalogue
+        cy.get(".lbh-tag").contains("Development").should("have.class", "lbh-tag--yellow");
     });
 });

--- a/src/components/environmentTags/environmentTags.component.jsx
+++ b/src/components/environmentTags/environmentTags.component.jsx
@@ -1,3 +1,5 @@
+import { includesCaseInsensitive } from "../../utility/utility";
+
 const EnvironmentTags = ({tags, error}) => {
   if(!tags) tags = [];
 
@@ -9,10 +11,10 @@ const EnvironmentTags = ({tags, error}) => {
   }
   return(
     <div className="env-tags">
-      <span className={`govuk-tag lbh-tag lbh-tag${tags.includes("Development") ? "--yellow" : "--grey"}`}>Development</span>
-      <span className={`govuk-tag lbh-tag lbh-tag${tags.includes("Staging") ? "--yellow" : "--grey"}`}>Staging</span>
-      <span className={`govuk-tag lbh-tag lbh-tag${tags.includes("Production") ? "--green" : "--grey"}`}>Production</span>
-      <span className={`govuk-tag lbh-tag lbh-tag${tags.includes("Deprecated") ? "--red" : "--hidden"}`}>Deprecated</span>
+      <span className={`govuk-tag lbh-tag lbh-tag${includesCaseInsensitive(tags, "Development") ? "--yellow" : "--grey"}`}>Development</span>
+      <span className={`govuk-tag lbh-tag lbh-tag${includesCaseInsensitive(tags, "Staging") ? "--yellow" : "--grey"}`}>Staging</span>
+      <span className={`govuk-tag lbh-tag lbh-tag${includesCaseInsensitive(tags, "Production") ? "--green" : "--grey"}`}>Production</span>
+      <span className={`govuk-tag lbh-tag lbh-tag${includesCaseInsensitive(tags, "Deprecated") ? "--red" : "--hidden"}`}>Deprecated</span>
     </div>
   )
 }

--- a/src/utility/utility.js
+++ b/src/utility/utility.js
@@ -17,3 +17,7 @@ export const camelToTitleCase = function(string){
 export const filterSwaggerPropertiesByType = (properties, filter) => {
     return properties.filter( property => property.type === filter)[0];
 }
+
+export const includesCaseInsensitive = (array, searchString)=> {
+    return array.some(x => x.toLowerCase() === searchString.toLowerCase());
+}


### PR DESCRIPTION
Currently, environment tags are case sensitive (i.e. must be capitalised in the swagger doc for the logic to work). 

This PR adds a function that returns true if an array contains a string (case insensitive). This is then implemented in the environment tags. and tests have been added.